### PR TITLE
Add support for configuration through the Fauna.configure method

### DIFF
--- a/lib/fauna.rb
+++ b/lib/fauna.rb
@@ -1,4 +1,5 @@
 require "fauna/version"
+require "fauna/configuration"
 
 module Fauna
 end

--- a/lib/fauna/configuration.rb
+++ b/lib/fauna/configuration.rb
@@ -1,0 +1,14 @@
+module Fauna
+  class << self
+    attr_accessor :configuration
+  end
+
+  def self.configure
+    self.configuration ||= Configuration.new
+    yield(configuration)
+  end
+  
+  class Configuration
+    attr_accessor :publisher_key, :username, :password
+  end
+end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -1,0 +1,11 @@
+require File.expand_path('../test_helper', __FILE__)
+
+class ConfigurationTest < MiniTest::Unit::TestCase
+  def test_configuration
+    Fauna.configure do |config|
+      config.publisher_key = '1234567890abcdef'
+    end
+
+    assert_equal '1234567890abcdef', Fauna.configuration.publisher_key
+  end
+end


### PR DESCRIPTION
I added the Fauna.configure method to configure publisher settings. Example:

``` ruby
Fauna.configure do |config|
  config.publisher_key = ENV["FAUNA_PUBLISHER_KEY"]
  config.username = ENV["FAUNA_USERNAME"]
  config.password = ENV["FAUNA_PASSWORD"]
end
```
