### PR TITLE
Add support for tests using live server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+test/credentials.yml

--- a/test/credentials.yml.sample
+++ b/test/credentials.yml.sample
@@ -1,0 +1,3 @@
+publisher_key: 'PutHereYourPublisherKey'
+username: 'lloyd@example.com'
+password: 'supersekrit'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,4 +18,23 @@ class MiniTest::Unit::TestCase
     net_http_resp = Net::HTTPResponse.new(1.0, code, message)
     RestClient::Response.create(fixture_data(fixture_file), net_http_resp, nil)
   end
+
+  def stub_response(*args, &block)
+    if ENV["LIVE"] == 'true'
+      block.call
+    else
+      RestClient.stub(*args, &block)
+    end
+  end
+end
+
+credentials_file = File.join(File.dirname(__FILE__), 'credentials.yml')
+if File.exists?(credentials_file)
+  require 'yaml'
+  credentials = YAML.load_file(credentials_file)
+  Fauna.configure do |config|
+    config.publisher_key = credentials["publisher_key"]
+    config.username = credentials["username"]
+    config.password = credentials["password"]
+  end
 end


### PR DESCRIPTION
To run tests against the server use the stub_response helper instead
of default Object#stub provided by minitest. Example

```
def test_class_create
  stub_response(:put, fake_response(201, "Created", "class")) do
    response = Fauna::Class.create("henwen")

    assert_equal "henwen", response["resource"]["name"]
    assert_equal "classes/henwen", response["resource"]["ref"]
  end
end
```

To run test in live mode, set the LIVE environment variable to true.

```
% LIVE=true ruby -Ilib test/class_test.rb
```

Same test will work correctly with mocks if LIVE env variable is ignored.
