### PR TITLE
Add block param to config section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Or install it yourself as:
 To get started configure the client with your publisher key:
 
 ```ruby
-Fauna.configure do
+Fauna.configure do |config|
   config.publisher_key = 'AQAASaskOlAAAQBJqyQLYAABe4PIuvsylBEAUrLuxtKJ8A'
 end
 ```


### PR DESCRIPTION
With this change, the config section in the readme now shows the necessary block param for `Fauna.configure`.
