### PR TITLE
Allow a publisher key to be specified in fauna.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,16 @@ controllers, based on credentials in `config/fauna.yml`:
 development:
   email: taran@example.com
   password: secret
+  publisher_key: secret_key
 test:
   email: taran@example.com
   password: secret
 ```
+
+The publisher key takes precedence over email/password. If a publisher
+key is specified, email and password can be omitted. If a publisher
+key is not specified, a new one will be generated each time the app is
+started.
 
 Then, in `config/initializers/fauna.rb`:
 

--- a/lib/fauna/rails.rb
+++ b/lib/fauna/rails.rb
@@ -22,16 +22,26 @@ if defined?(Rails)
         end
 
         if !@silent
-          STDERR.puts ">> Using Fauna account #{credentials["email"].inspect} for #{APP_NAME.inspect}."
+          if credentials["publisher_key"]
+            STDERR.puts ">> Using Fauna publisher key #{credentials["publisher_key"].inspect} for #{APP_NAME.inspect}."
+          else
+            STDERR.puts ">> Using Fauna account #{credentials["email"].inspect} for #{APP_NAME.inspect}."
+          end
+
           STDERR.puts ">> You can change this in config/fauna.yml or ~/.fauna.yml."
         end
 
-        self.root_connection = Connection.new(
-          :email => credentials["email"],
-          :password => credentials["password"],
-        :logger => Rails.logger)
+        if credentials["publisher_key"]
+          publisher_key = credentials["publisher_key"]
+        else
+          self.root_connection = Connection.new(
+            :email => credentials["email"],
+            :password => credentials["password"],
+          :logger => Rails.logger)
 
-        publisher_key = root_connection.post("keys/publisher")["resource"]["key"]
+          publisher_key = root_connection.post("keys/publisher")["resource"]["key"]
+        end
+
         self.connection = Connection.new(publisher_key: publisher_key, logger: Rails.logger)
       else
         if !@silent


### PR DESCRIPTION
If a publisher key is specified, the email and password
credentials can be omitted. If it isn't, email and password
credentials are required and a new publisher key will be
generated (as before).

Discussed in #24.
