### PR TITLE
Don't reuse the default attributes hash across instances

### DIFF
--- a/lib/fauna/resource.rb
+++ b/lib/fauna/resource.rb
@@ -150,15 +150,17 @@ module Fauna
     # TODO: make this configurable, and possible to invert to a white list
     UNASSIGNABLE_ATTRIBUTES = %w(ts deleted fauna_class).inject({}) { |h, attr| h.update attr => true }
 
-    DEFAULT_ATTRIBUTES = { 'data' => {}, 'references' => {}, 'constraints' => {} }
-
     def struct=(attributes)
-      DEFAULT_ATTRIBUTES.merge(attributes).each do |name, val|
+      default_attributes.merge(attributes).each do |name, val|
         send "#{name}=", val unless UNASSIGNABLE_ATTRIBUTES[name.to_s]
       end
     end
 
   private
+
+    def default_attributes
+      { 'data' => {}, 'references' => {}, 'constraints' => {} }
+    end
 
     def getter_method(method)
       field = method.to_s

--- a/test/class_test.rb
+++ b/test/class_test.rb
@@ -6,6 +6,12 @@ class ClassTest < MiniTest::Unit::TestCase
     @model = Fauna::Resource.new('classes/pigs')
   end
 
+  def test_new
+    settings = Fauna::Resource.new('settings', :ref => 'settings/12345678', :email => 'test@test.com')
+    user = Fauna::Resource.new('users', :ref => 'users/87654321')
+    assert user.data.object_id != settings.data.object_id
+  end
+
   def test_create
     pig = Fauna::Resource.create 'classes/pigs', :data => { :visited => true }
     assert_equal true, pig.data['visited']


### PR DESCRIPTION
Fixes #61
