### PR TITLE
Update driver info

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2015 Fauna, Inc.
+Copyright 2017 Fauna, Inc.
 
 Licensed under the Mozilla Public License, Version 2.0 (the "License"); you may
 not use this software except in compliance with the License. You may obtain a 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # FaunaDB
 
-[![Build Status](https://img.shields.io/travis/faunadb/faunadb-ruby/master.svg?maxAge=21600)](https://travis-ci.org/faunadb/faunadb-ruby)
-[![Coverage Status](https://img.shields.io/codecov/c/github/faunadb/faunadb-ruby/master.svg?maxAge=21600)](https://codecov.io/gh/faunadb/faunadb-ruby/branch/master)
+[![Build Status](https://img.shields.io/travis/fauna/faunadb-ruby/master.svg?maxAge=21600)](https://travis-ci.org/fauna/faunadb-ruby)
+[![Coverage Status](https://img.shields.io/codecov/c/github/fauna/faunadb-ruby/master.svg?maxAge=21600)](https://codecov.io/gh/fauna/faunadb-ruby/branch/master)
 [![Gem Version](https://img.shields.io/gem/v/fauna.svg?maxAge=21600)](https://rubygems.org/gems/fauna)
-[![License](https://img.shields.io/badge/license-MPL_2.0-blue.svg?maxAge=2592000)](https://raw.githubusercontent.com/faunadb/faunadb-ruby/master/LICENSE)
+[![License](https://img.shields.io/badge/license-MPL_2.0-blue.svg?maxAge=2592000)](https://raw.githubusercontent.com/fauna/faunadb-ruby/master/LICENSE)
 
 Ruby driver for [FaunaDB](https://fauna.com).
 
@@ -23,11 +23,11 @@ And then execute:
 
 ## Documentation
 
-The driver documentation is [hosted on GitHub Pages](https://faunadb.github.io/faunadb-ruby/).
+The driver documentation is [hosted on GitHub Pages](https://fauna.github.io/faunadb-ruby/).
 
 Please see the [FaunaDB Documentation](https://fauna.com/documentation) for
 a complete API reference, or look in
-[`/test`](https://github.com/faunadb/faunadb-ruby/tree/master/test) for more
+[`/test`](https://github.com/fauna/faunadb-ruby/tree/master/test) for more
 examples.
 
 ## Compatibility

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ GitHub pull requests are very welcome.
 
 ## LICENSE
 
-Copyright 2016 [Fauna, Inc.](https://fauna.com/)
+Copyright 2017 [Fauna, Inc.](https://fauna.com/)
 
 Licensed under the Mozilla Public License, Version 2.0 (the
 "License"); you may not use this software except in compliance with

--- a/fauna.gemspec
+++ b/fauna.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.email = 'priority@fauna.com'
   s.summary = 'FaunaDB Ruby driver'
   s.description = 'Ruby driver for FaunaDB.'
-  s.homepage = 'https://github.com/faunadb/faunadb-ruby'
+  s.homepage = 'https://github.com/fauna/faunadb-ruby'
   s.license = 'MPL-2.0'
 
   s.files = %w(CHANGELOG Gemfile LICENSE README.md Rakefile fauna.gemspec lib/fauna.rb) + Dir.glob('lib/fauna/**') + Dir.glob('spec/**')


### PR DESCRIPTION
Bumps copyright date and updates github links for the org change.

Part of https://github.com/fauna/sales-engineering/issues/525.