### PR TITLE
Handle HTTP errors 502 and 504 as UnavailableError

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 2.3.1.pre
+* Handle HTTP errors 502 and 504 as `Fauna::UnavailableError`.
 
 2.3.0
 * Change default domain to `db.fauna.com`.

--- a/lib/fauna/client.rb
+++ b/lib/fauna/client.rb
@@ -215,9 +215,7 @@ module Fauna
         end_time = Time.now
 
         message = e.class.name
-        unless e.message.nil?
-          message += ": #{e.message}"
-        end
+        message += ": #{e.message}" unless e.message.nil?
 
         request_result = RequestResult.new(self,
             action, path, query, data,
@@ -237,10 +235,6 @@ module Fauna
           start_time, end_time)
 
       @observer.call(request_result) unless @observer.nil?
-
-      if response_json.nil? && response.status != 503
-        fail UnexpectedError.new('Invalid JSON.', request_result)
-      end
 
       FaunaError.raise_for_status_code(request_result)
       UnexpectedError.get_or_raise request_result, response_content, :resource

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -128,9 +128,24 @@ RSpec.describe 'Fauna Errors' do
       expect { stub_client.get '' }.to raise_fauna_error(Fauna::UnavailableError, 'unavailable')
     end
 
+    it 'handles upstream 502' do
+      stub_client = stub_get 502, 'Bad gateway'
+      expect { stub_client.get '' }.to raise_error(Fauna::UnavailableError, 'Bad gateway')
+    end
+
     it 'handles upstream 503' do
       stub_client = stub_get 503, 'Unable to reach server'
       expect { stub_client.get '' }.to raise_error(Fauna::UnavailableError, 'Unable to reach server')
+    end
+
+    it 'handles upstream 504' do
+      stub_client = stub_get 504, 'Server timeout'
+      expect { stub_client.get '' }.to raise_error(Fauna::UnavailableError, 'Server timeout')
+    end
+
+    it 'handles upstream json 503' do
+      stub_client = stub_get 503, '{ "error" : "service unavailable" }'
+      expect { stub_client.get '' }.to raise_error(Fauna::UnavailableError, '{ "error" : "service unavailable" }')
     end
 
     it 'handles timeout error' do


### PR DESCRIPTION
Proxies in front of FaunaDB (nginx, etc) can throw 502 and 504 when FaunaDB is not online (restarts, etc). This handles those states.

Also refactors the code to be a bit cleaner and all in one place.