### PR TITLE
Update gemspec with community support message

### DIFF
--- a/fauna.gemspec
+++ b/fauna.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.author = 'Fauna, Inc.'
   s.email = 'priority@fauna.com'
   s.summary = 'FaunaDB Ruby driver'
-  s.description = 'Ruby driver for FaunaDB.'
+  s.description = "FaunaDB's Ruby driver is now \"community-supported\". If you are using this driver in production, it will continue to work as expected. However, new features won't be exposed in the driver unless the necessary changes are contributed by a community member. Please email product@fauna.com if you have any questions/concerns about the model or would like to take a more active role in the development of the driver (eg. partnering with us and operating as a \"maintainer\" for the driver)."
   s.homepage = 'https://github.com/fauna/faunadb-ruby'
   s.license = 'MPL-2.0'
 


### PR DESCRIPTION
Description here will update our [rubygems](https://rubygems.org/gems/fauna/versions/3.0.0) page when we publish a new patch version. Other gems seem to manually insert newlines in their longer messages which I did not do here.

I don't know how to preview what this new longer description will look before publishing.